### PR TITLE
Corrected dev "config.json" location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then open up a webbrowser and go to the site
 
 ## Development Usage
 - Install NodeJS 8.0 or higher
-- Copy the `_scripts/config/config.dev.json` to here `app/config/config.json`
+- Copy the `_scripts/config/config.dev.json` to here `app/src/config/config.json`
 - Run `npm install` in the root project folder
 - Run `npm run webpack` in the root project folder
 - Run `npm run dev` in the root project folder


### PR DESCRIPTION
I had a hard time understanding why my config.json was not taken into account although I was correctly following the instructions.